### PR TITLE
getTask reject instead of null

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -354,8 +354,11 @@ function getTask(ref, status = STATUSES.available) {
                         .then(snap => {
                             resolve(snap.val())
                         })
+                        .catch(err => {
+                            reject(err)
+                        })
                 } else {
-                    resolve(null)
+                    reject('snapshot is null')
                 }
             })
     })


### PR DESCRIPTION
getTask rejects instead of returning null.